### PR TITLE
Add timezone offset to outage active/expired checks

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -26,14 +26,6 @@ export function isOutageActive(dateStr: string, startHour: number, startMinute: 
 
     const currentDate = new Date();
 
-    console.log(`current date: ${currentDate}`);
-    console.log(`outage start date: ${outageStartDate}`);
-
-    console.log(
-        `current date ts: ${currentDate.getTime()}, outage date ts: ${outageStartDate.getTime()}`,
-        currentDate.getTime() >= outageStartDate.getTime()
-    );
-
     return currentDate.getTime() >= outageStartDate.getTime();
 }
 
@@ -55,6 +47,8 @@ export function isOutageExpired(dateStr: string, startHour: number, endHour: num
     const timeZoneOffset = Math.abs(outageEndDate.getTimezoneOffset());
     const hoursToAdd = (parseInt(timeZoneDifference) * 60) - timeZoneOffset;
 
+    console.log(`time zone offset ${timeZoneOffset}, hours to add ${hoursToAdd}`);
+
     if (hoursToAdd > 0) {
         outageEndDate.setHours(endHour + hoursToAdd);
     }
@@ -67,6 +61,14 @@ export function isOutageExpired(dateStr: string, startHour: number, endHour: num
     }
 
     const currentDate = new Date();
+
+    console.log(`current date: ${currentDate}`);
+    console.log(`outage end date: ${outageEndDate}`);
+
+    console.log(
+        `current date ts: ${currentDate.getTime()}, outage date ts: ${outageEndDate.getTime()}`,
+        currentDate.getTime() >= outageEndDate.getTime()
+    );
 
     return currentDate.getTime() >= outageEndDate.getTime();
 }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -23,6 +23,8 @@ export function isOutageActive(dateStr: string, startHour: number, startMinute: 
 
     console.log(`current date: ${currentDate}`);
     console.log(`outage start date: ${outageStartDate}`);
+    console.log(`current date offset: ${currentDate.getTimezoneOffset()}`);
+    console.log(`outage start date offset: ${outageStartDate.getTimezoneOffset()}`);
 
     console.log(
         `current date ts: ${currentDate.getTime()}, outage date ts: ${outageStartDate.getTime()}`,
@@ -106,8 +108,6 @@ export function getTimesAndActiveOutage(startTime: string, endTime: string) {
         };
     }
 
-    console.log(`is outage active: ${isOutageActive(startTime, parseInt(startHour), parseInt(startMinute))}`);
-
     return {
         activeOutage: isOutageActive(startTime, parseInt(startHour), parseInt(startMinute)),
         expiredOutage: false,
@@ -136,10 +136,7 @@ export async function getActiveOutages() {
         const timesAndIsActiveOutage = getTimesAndActiveOutage(shutdownperiods.start, shutdownperiods.end);
         outage.expiredOutage = timesAndIsActiveOutage.expiredOutage;
 
-        console.log(timesAndIsActiveOutage);
-
         if (timesAndIsActiveOutage.activeOutage && outage.statustext !== 'Cancelled') {
-            console.log(outage.statustext);
             outage.statustext = 'Active';
         }
     });

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -12,19 +12,22 @@ import { z } from 'zod';
  * @returns {Boolean}
  */
 export function isOutageActive(dateStr: string, startHour: number, startMinute: number) {
-    console.log(dateStr);
-
     const outageStartDate = new Date(dateStr);
 
-    outageStartDate.setHours(startHour);
+    const timeZoneDifference = dateStr.split('+')[1].split(':')[0];
+
+    const timeZoneOffset = Math.abs(outageStartDate.getTimezoneOffset());
+    const hoursToAdd = (parseInt(timeZoneDifference) * 60) - timeZoneOffset;
+
+    if (hoursToAdd > 0) {
+        outageStartDate.setHours(startHour + hoursToAdd);
+    }
     outageStartDate.setMinutes(startMinute);
 
     const currentDate = new Date();
 
     console.log(`current date: ${currentDate}`);
     console.log(`outage start date: ${outageStartDate}`);
-    console.log(`current date offset: ${currentDate.getTimezoneOffset()}`);
-    console.log(`outage start date offset: ${outageStartDate.getTimezoneOffset()}`);
 
     console.log(
         `current date ts: ${currentDate.getTime()}, outage date ts: ${outageStartDate.getTime()}`,
@@ -46,7 +49,15 @@ export function isOutageActive(dateStr: string, startHour: number, startMinute: 
  */
 export function isOutageExpired(dateStr: string, startHour: number, endHour: number, endMinute: number) {
     const outageEndDate = new Date(dateStr);
-    outageEndDate.setHours(endHour);
+
+    const timeZoneDifference = dateStr.split('+')[1].split(':')[0];
+
+    const timeZoneOffset = Math.abs(outageEndDate.getTimezoneOffset());
+    const hoursToAdd = (parseInt(timeZoneDifference) * 60) - timeZoneOffset;
+
+    if (hoursToAdd > 0) {
+        outageEndDate.setHours(endHour + hoursToAdd);
+    }
     outageEndDate.setMinutes(endMinute);
 
     // Set end date to next day if start hour is greater than the end hour,

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -19,8 +19,6 @@ export function isOutageActive(dateStr: string, startHour: number, startMinute: 
     const timeZoneOffset = Math.abs(outageStartDate.getTimezoneOffset());
     const hoursToAdd = parseInt(timeZoneDifference) - (timeZoneOffset / 60);
 
-    console.log(`time zone offset ${timeZoneOffset}, hours to add ${hoursToAdd}`);
-
     if (hoursToAdd > 0) {
         outageStartDate.setHours(startHour + hoursToAdd);
     }
@@ -49,8 +47,6 @@ export function isOutageExpired(dateStr: string, startHour: number, endHour: num
     const timeZoneOffset = Math.abs(outageEndDate.getTimezoneOffset());
     const hoursToAdd = parseInt(timeZoneDifference) - (timeZoneOffset / 60);
 
-    console.log(`time zone offset ${timeZoneOffset}, hours to add ${hoursToAdd}`);
-
     if (hoursToAdd > 0) {
         outageEndDate.setHours(endHour + hoursToAdd);
     }
@@ -63,14 +59,6 @@ export function isOutageExpired(dateStr: string, startHour: number, endHour: num
     }
 
     const currentDate = new Date();
-
-    console.log(`current date: ${currentDate}`);
-    console.log(`outage end date: ${outageEndDate}`);
-
-    console.log(
-        `current date ts: ${currentDate.getTime()}, outage date ts: ${outageEndDate.getTime()}`,
-        currentDate.getTime() >= outageEndDate.getTime()
-    );
 
     return currentDate.getTime() >= outageEndDate.getTime();
 }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -17,7 +17,9 @@ export function isOutageActive(dateStr: string, startHour: number, startMinute: 
     const timeZoneDifference = dateStr.split('+')[1].split(':')[0];
 
     const timeZoneOffset = Math.abs(outageStartDate.getTimezoneOffset());
-    const hoursToAdd = (parseInt(timeZoneDifference) * 60) - timeZoneOffset;
+    const hoursToAdd = parseInt(timeZoneDifference) - (timeZoneOffset / 60);
+
+    console.log(`time zone offset ${timeZoneOffset}, hours to add ${hoursToAdd}`);
 
     if (hoursToAdd > 0) {
         outageStartDate.setHours(startHour + hoursToAdd);
@@ -45,7 +47,7 @@ export function isOutageExpired(dateStr: string, startHour: number, endHour: num
     const timeZoneDifference = dateStr.split('+')[1].split(':')[0];
 
     const timeZoneOffset = Math.abs(outageEndDate.getTimezoneOffset());
-    const hoursToAdd = (parseInt(timeZoneDifference) * 60) - timeZoneOffset;
+    const hoursToAdd = parseInt(timeZoneDifference) - (timeZoneOffset / 60);
 
     console.log(`time zone offset ${timeZoneOffset}, hours to add ${hoursToAdd}`);
 

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -106,6 +106,8 @@ export function getTimesAndActiveOutage(startTime: string, endTime: string) {
         };
     }
 
+    console.log(`is outage active: ${isOutageActive(startTime, parseInt(startHour), parseInt(startMinute))}`);
+
     return {
         activeOutage: isOutageActive(startTime, parseInt(startHour), parseInt(startMinute)),
         expiredOutage: false,
@@ -134,7 +136,10 @@ export async function getActiveOutages() {
         const timesAndIsActiveOutage = getTimesAndActiveOutage(shutdownperiods.start, shutdownperiods.end);
         outage.expiredOutage = timesAndIsActiveOutage.expiredOutage;
 
+        console.log(timesAndIsActiveOutage);
+
         if (timesAndIsActiveOutage.activeOutage && outage.statustext !== 'Cancelled') {
+            console.log(outage.statustext);
             outage.statustext = 'Active';
         }
     });

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -12,16 +12,22 @@ import { z } from 'zod';
  * @returns {Boolean}
  */
 export function isOutageActive(dateStr: string, startHour: number, startMinute: number) {
-    const outageStartDate = new Date(dateStr);
+    console.log(dateStr);
 
-    console.log(outageStartDate);
+    const outageStartDate = new Date(dateStr);
 
     outageStartDate.setHours(startHour);
     outageStartDate.setMinutes(startMinute);
 
     const currentDate = new Date();
 
-    console.log(currentDate);
+    console.log(`current date: ${currentDate}`);
+    console.log(`outage start date: ${outageStartDate}`);
+
+    console.log(
+        `current date ts: ${currentDate.getTime()}, outage date ts: ${outageStartDate.getTime()}`,
+        currentDate.getTime() >= outageStartDate.getTime()
+    );
 
     return currentDate.getTime() >= outageStartDate.getTime();
 }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -13,10 +13,15 @@ import { z } from 'zod';
  */
 export function isOutageActive(dateStr: string, startHour: number, startMinute: number) {
     const outageStartDate = new Date(dateStr);
+
+    console.log(outageStartDate);
+
     outageStartDate.setHours(startHour);
     outageStartDate.setMinutes(startMinute);
 
     const currentDate = new Date();
+
+    console.log(currentDate);
 
     return currentDate.getTime() >= outageStartDate.getTime();
 }


### PR DESCRIPTION
The `Vercel` servers use the `GMT` timezone, which can cause issues where outages are shown as `Active` when they have not started.

This was found to happen 12 or 13 hours before the start time of a planned outage, due to the outage date strings being set for the `NZT` timezone.

To fix this, inside the `isOutageActive` and `isOutageExpired` functions, the timezone difference is checked (should be 12 or 13), and some hours are added to an outage's start and end date if an offset exists, e.g:
```
// 12 - 0 = 12 hours added to the (initial) start/end time
const hoursToAdd = parseInt(dateStr.split('+')[1].split(':')[0]) - (Math.abs(outageStartDate.getTimezoneOffset()) / 60);
```